### PR TITLE
Save base weapon name instead of weapon + specials

### DIFF
--- a/plugins/magic/helpers/magic_gear_helper.rb
+++ b/plugins/magic/helpers/magic_gear_helper.rb
@@ -95,8 +95,8 @@ module AresMUSH
         combatant.update(prior_ammo: prior_ammo)
       end
 
-      combatant.update(weapon_name: weapon)
       combatant.update(weapon_specials: specials ? specials.map { |s| s.titlecase }.uniq : [])
+      combatant.update(weapon_name: weapon)
       combatant.update(ammo: current_ammo)
       combatant.update(max_ammo: max_ammo)
 

--- a/plugins/magic/helpers/spell_cast_helper.rb
+++ b/plugins/magic/helpers/spell_cast_helper.rb
@@ -211,17 +211,18 @@ module AresMUSH
       if weapon_special
         weapon_special.update(rounds: spell['rounds'])
       else
+        target_weapon = target.weapon.before('+')
         weapon_special = {
         name: spell['weapon_specials'],
         # Needs to be +1 because the newturn immediately after cast will do -1
         rounds: spell['rounds'] + 1,
-        weapon: target.weapon,
+        weapon: target_weapon,
         combatant: target
       }
       MagicWeaponSpecials.create(weapon_special)
       end
 
-      Magic.set_magic_weapon(target, target.weapon)
+      Magic.set_magic_weapon(target, target_weapon)
 
       if (spell['heal_points'] && wound)
         message = []


### PR DESCRIPTION
 Save base weapon name instead of weapon + specials so that switching weapons will find ALL specials associated with that weapon. 

Only pass through the base weapon for weapon switch for the same reason, and change order of messaging so that all specials are set before the weapon change is called.